### PR TITLE
git clone ... recurse-submodules to get pydal

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installing E-Vote
 
 E-Vote uses the [web2py](http://web2py.com/) framework and can be installed like any other web2py application; see the web2py documentation for details.  If you just want to try out E-Vote quickly, here is one way to get it up and running on your laptop:
 
-      $ git clone https://github.com/web2py/web2py.git
+      $ git clone https://github.com/web2py/web2py.git --recurse-submodules
       $ cd web2py/applications
       $ git clone https://github.com/mdipierro/evote.git
       $ cd ..


### PR DESCRIPTION
carl@twist:~/src/web2py$ python web2py.py
Traceback (most recent call last):
  File "web2py.py", line 18, in <module>
    import gluon.widget
  File "/home/carl/src/web2py/gluon/__init__.py", line 29, in <module>
    "You can also download a complete copy from http://www.web2py.com."
RuntimeError: web2py depends on pydal, which apparently you have not installed.
Probably you cloned the repository using git without '--recursive'
To fix this, please run (from inside your web2py folder):

     git submodule update --init --recursive

You can also download a complete copy from http://www.web2py.com.